### PR TITLE
kinkonkan: fix crossstitch regression

### DIFF
--- a/src/variety-common/Graphic.js
+++ b/src/variety-common/Graphic.js
@@ -403,7 +403,7 @@ pzpr.classmgr.makeCommon({
 							addwidth = basewidth / 2;
 						}
 
-						if (info > 0) {
+						if (this.pid !== "kinkonkan" && info > 0) {
 							if (info & (slash ? 4 : 8)) {
 								color = this.noerrcolor;
 							} else if (info & 1) {


### PR DESCRIPTION
the crossstitch changes assumed nobody else was using qinfo, but
kinkonkan uses it for light beam logic

this caused a bug where shining a beam from above on a \ mirror which
was also the first in reading order made it disappear (color was never
set), and shining a beam from above on a / mirror made it gray

(cherry picked from commit d39dca3a981213030ac9a6e781d5075e3d704373)