### PR TITLE
Added functionality to automatically save board states in localStorage

### DIFF
--- a/src-ui/js/ui/Boot.js
+++ b/src-ui/js/ui/Boot.js
@@ -1,7 +1,6 @@
 // Boot.js v3.4.0
 
 (function() {
-
 	/********************************/
 	/* 初期化時のみ使用するルーチン */
 	/********************************/
@@ -17,18 +16,18 @@
 		var pzl;
 		// Get URL search hash and check localStorage to see if a board state is saved
 		if (!localStorageAvailable()) {
-			pzl = importData()
+			pzl = importData();
 		} else {
-			var key = 'pzpr_' + getPuzzleString()
-			var puzzleStr = localStorage.getItem(key)
+			var key = "pzpr_" + getPuzzleString();
+			var puzzleStr = localStorage.getItem(key);
 			if (!puzzleStr) {
-				pzl = importData()
+				pzl = importData();
 			} else {
-				pzl = importData(puzzleStr) // Local storage was available and key was found
+				pzl = importData(puzzleStr); // Local storage was available and key was found
 			}
 		}
 		if (!pzl) {
-			setTimeout(boot,0);
+			setTimeout(boot, 0);
 		}
 		startPuzzle();
 	});
@@ -42,7 +41,7 @@
 			} else {
 				onload_pzl = importFromString(string);
 			}
-			
+
 			/* 指定されたパズルがない場合はさようなら～ */
 			if (!onload_pzl || !onload_pzl.pid) {
 				failOpen();
@@ -126,7 +125,7 @@
 			onload_option[RegExp.$1] = RegExp.$2;
 			search = RegExp.$3;
 		}
-		return search
+		return search;
 	}
 	//Import from a puzzle string. This can come from the URL or from localStorage
 	function importFromString(string) {
@@ -148,10 +147,10 @@
 
 	//Taken directly from stackoverflow. Apparently this is the most broadly compatible version. https://stackoverflow.com/questions/16427636/check-if-localstorage-is-available
 	function localStorageAvailable() {
-		var test = 'test';
+		var test = "test";
 		try {
-			localStorage.setItem(test,test);
-			localStorage.removeItem(test)
+			localStorage.setItem(test, test);
+			localStorage.removeItem(test);
 			return true;
 		} catch (e) {
 			return false;
@@ -161,27 +160,27 @@
 	//Save board state. Creates an entry in localStorage whose key is a 'pzpr_' identifier plus the current board state puzzle string.
 	//Board state puzzle string is the same thing you get from duplicating the board state
 	function saveBoardState() {
-		var key = 'pzpr_' + getPuzzleString()
+		var key = "pzpr_" + getPuzzleString();
 		var url = ui.puzzle.getURL(
-					pzpr.parser.URL_PZPRFILE,
-					ui.puzzle.playeronly ? "player" : "editor"
-				);
+			pzpr.parser.URL_PZPRFILE,
+			ui.puzzle.playeronly ? "player" : "editor"
+		);
 		//Strip url to the last option. This is the "puzzle string" we want
-		url = url.substring(url.indexOf('?')+1) //Skip to the search parameters part of the url
+		url = url.substring(url.indexOf("?") + 1); //Skip to the search parameters part of the url
 		while (url.match(/^(\w+)\=(\w+)\&(.*)/)) {
 			url = RegExp.$3;
 		}
 		try {
-			localStorage.setItem(key,url)
+			localStorage.setItem(key, url);
 		} catch (e) {
-			console.log(e)
+			console.log(e);
 		}
 	}
 
 	//Events that trigger a board state save
 	document.addEventListener("visibilitychange", function() {
-        if (document.visibilityState === "hidden") {
-            saveBoardState();
-        }
-    });
+		if (document.visibilityState === "hidden") {
+			saveBoardState();
+		}
+	});
 })();

--- a/src-ui/js/ui/Boot.js
+++ b/src-ui/js/ui/Boot.js
@@ -171,7 +171,11 @@
 		while (url.match(/^(\w+)\=(\w+)\&(.*)/)) {
 			url = RegExp.$3;
 		}
-		localStorage.setItem(key,url)
+		try {
+			localStorage.setItem(key,url)
+		} catch (e) {
+			console.log(e)
+		}
 	}
 
 	//Events that trigger a board state save


### PR DESCRIPTION
Updated Boot.js to do caching in `localStorage`. This is basically the implementation that penpa uses, except:
1. I used the encodings already available from the functionality that duplicates the board and the functionality that correlates URL to puzzle. It creates a new URL that incorporates the whole board state then correlates the "search" part of the URL with the "search" part of the base URL. 
2. It does not fire on the `beforeunload` browser event. I noticed that the `visibilitychange` event was firing at pretty much any time I could imagine wanting to cache, and upon further investigation it seems `beforeunload` is only really recommended when there is a desire to bring up a dialog and allow the user to cancel their decision to leave

This was tested and works perfectly on Chrome Version 142.0.7444.163 (Official Build) (64-bit). I don't really know what the best way is to go about testing on other browsers, but the code as written should be able to discern if there is no `localStorage` available and simply not do the caching in that case.

I also tested it for a simple loop up to 75x75, which has a pretty long encoding, and it was fine. Upon inspection, it looks like this fairly extreme case gives me ~67,000 characters in the URL. The base URL is considerably shorter, so this encoding is like <0.2 MB with a high estimate. That means with a `localStorage` cap of ~5MB for most browsers, there is very unlikely to be a real single puzzle that messes with `localStorage`. Right now if anything goes wrong with the cache write, all that really happens is that the caching doesn't happen

Final misc. thought: There isn't really a great way to give users an option to cache or not cache, since it seems that all of the persistent options available (e.g., yajilin styling) are encoded directly in URLs. That said, I don't believe penpa gives you this option either and that seems to work fine with almost exactly this implementation